### PR TITLE
Resolve modern SWIG error

### DIFF
--- a/pcap.c
+++ b/pcap.c
@@ -850,7 +850,7 @@ SWIG_Python_AddErrorMsg(const char* mesg)
     Py_DECREF(old_str);
     Py_DECREF(value);
   } else {
-    PyErr_Format(PyExc_RuntimeError, mesg);
+    PyErr_Format(PyExc_RuntimeError, "%s", mesg);
   }
 }
 


### PR DESCRIPTION
Fix for "format not a string literal and no format arguments" with SWIG 3.0
